### PR TITLE
Store memory limit in MB insted of Bytes in CMS exporter

### DIFF
--- a/scripts/exporters/CMS.py
+++ b/scripts/exporters/CMS.py
@@ -116,7 +116,7 @@ class JSONExporter:
             "code": task_data["name"],
             "name": task_data["title"],
             "time_limit": task_data["time_limit"],
-            "memory_limit": task_data["memory_limit"]*1024*1024,
+            "memory_limit": task_data["memory_limit"],
             "score_precision": task_data.get("score_precision", 2),
             "task_type": task_type,
             "task_type_params": json.dumps(task_type_params),


### PR DESCRIPTION
Hi,

I think ML should be stored in megabytes, not bytes. Because I had set it to 512 in `problem.json` and after exporting from TPS and importing it to CMS, CMS showed me `536870912 MB` ML.

After changing this line of code, the problem was fixed.