### PR TITLE
Add online installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,15 @@ You may find the web interface at https://github.com/ioi-2017/tps-web.
 
 Installation
 ------------
-After cloning the project, just run `install-tps.sh` (or `install-tps.bat` in Windows with MSYS/Cygwin).
-This will add `tps` command to PATH and also add bash completion for it.
+Run the following command to install TPS on Linux/MacOS/Windows (with WSL):
 
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
+```
+
+To install TPS in Windows (with MSYS/Cygwin), clone the project and, run `install-tps.bat`.
+
+Above methods will add `tps` command to PATH and also add bash completion for it.
 
 Behavior
 --------

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ You may find the web interface at https://github.com/ioi-2017/tps-web.
 
 Installation
 ------------
+
 Run the following command to install TPS on Linux/MacOS/Windows (with WSL):
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
 ```
 
-To install TPS in Windows (with MSYS/Cygwin), clone the project and, run `install-tps.bat`.
-
-Above methods will add `tps` command to PATH and also add bash completion for it.
+This will add `tps` command to PATH and also adds bash completion for it. For other installation methods 
+please refer to the detailed documentation in the [`docs`](docs) directory.
 
 Behavior
 --------

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,15 @@ Run the following command to install TPS on Linux/MacOS/Windows (with WSL):
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
 ```
 
-Online installer assumes you have `git` installed in your system.
+Online installer assumes you have `git` installed in your system. It clones the tps repo and installs it.
+
+You can customize its installation by setting these enviornment variables before running the above command:
+
+| Variable                  | Description                               | Default                               |
+| ------------------------- | ----------------------------------------- | ------------------------------------- |
+| `TPS_LOCAL_REPO`          | Directory to store TPS code repository in | `$HOME/.local/share/tps`              |
+| `TPS_REMOTE_REPO_GIT_URL` | Git URL of the remote repo                | `https://github.com/ioi-2017/tps.git` | 
+| `TPS_REMOTE_BRANCH`       | Branch to install from                    | `master`                              |
 
 ### Manual installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,10 +13,23 @@ The TPS has two interfaces: a command-line interface that is ideal for those who
 
 The following sections describe these interfaces.
 
-# Command-line interface
+# Installing command-line interface
 
-To install the TPS command-line interface, clone the `tps` repository,
- and install it using the following commands (in Linux):
+It is possible to install the TPS command-line interface using an online installer, or install it manually.
+
+## Online installation
+
+Run the following command to install TPS on Linux/MacOS/Windows (with WSL):
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
+```
+
+Online installer assumes you have `git` installed in your system.
+
+### Manual installation
+
+Clone the `tps` repository, and install it using the following commands (in Linux):
 
 ```
 cd tps

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -86,8 +86,8 @@ function clone_tps {
 
 	ostype=$(uname)
 	if [ -z "${ostype%CYGWIN*}" ] && git --version | grep -q msysgit; then
-		fmt_error "Windows/MSYS Git is not supported on Cygwin. Make sure the" \
-			"Cygwin git package is installed and is first on the \$PATH"
+		fmt_error "Windows/MSYS Git is not supported on Cygwin." \
+			"Make sure the Cygwin git package is installed and is first on the \$PATH"
 		exit 1
 	fi
 

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-# Make sure important variables exist if not already defined
+# Making sure important variables exist if not already defined
 #
 # $USER is defined by login(1) which is not always executed (e.g. containers)
 # POSIX: https://pubs.opengroup.org/onlinepubs/009695299/utilities/id.html
@@ -27,7 +27,7 @@ HOME="${HOME:-$(getent passwd $USER 2> "/dev/null" | cut -d: -f6)}"
 # macOS does not have getent, but this works even if $HOME is unset
 HOME="${HOME:-$(eval echo ~$USER)}"
 
-# Directory of TPS code repository
+# Directory to store TPS code repository in
 TPS_LOCAL_REPO="${TPS_LOCAL_REPO:-$HOME/.local/share/tps}"
 
 # Tps cli file path. It will be a symlink from the code repository and the directory should be added to the path.
@@ -45,22 +45,22 @@ fmt_error() {
 }
 
 user_can_sudo() {
-  # Check if sudo is installed
+  # Checking if sudo is installed
   command_exists sudo || return 1
   # The following command has 3 parts:
   #
-  # 1. Run `sudo` with `-v`. Does the following:
+  # 1. Runs `sudo` with `-v`. Does the following:
   #    • with privilege: asks for a password immediately.
   #    • without privilege: exits with error code 1 and prints the message:
   #      Sorry, user <username> may not run sudo on <hostname>
   #
-  # 2. Pass `-n` to `sudo` to tell it to not ask for a password. If the
+  # 2. Passes `-n` to `sudo` to tell it to not ask for a password. If the
   #    password is not required, the command will finish with exit code 0.
   #    If one is required, sudo will exit with error code 1 and print the
   #    message:
   #    sudo: a password is required
   #
-  # 3. Check for the words "may not run sudo" in the output to really tell
+  # 3. Checks for the words "may not run sudo" in the output to really tell
   #    whether the user has privileges or not. For that we have to make sure
   #    to run `sudo` in the default locale (with `LANG=`) so that the message
   #    stays consistent regardless of the user's locale.
@@ -70,7 +70,7 @@ user_can_sudo() {
 
 
 clone_tps() {
-	# Prevent the cloned repository from having insecure permissions. Failing to do
+	# Preventing the cloned repository from having insecure permissions. Failing to do
 	# so causes compinit() calls to fail with "command not found: compdef" errors
 	# for users with insecure umasks (e.g., "002", allowing group writability). Note
 	# that this will be ignored under Cygwin by default, as Windows ACLs take
@@ -94,7 +94,7 @@ clone_tps() {
 		exit 1
 	fi
 
-	# Manual clone with git config options to support git < v1.7.2
+	# Manual cloning with git config options to support git < v1.7.2
 	mkdir -p "$TPS_LOCAL_REPO"
 	git init --quiet "$TPS_LOCAL_REPO" && cd "$TPS_LOCAL_REPO" \
 	&& git config core.eol lf \
@@ -114,7 +114,7 @@ clone_tps() {
 		fmt_error "git clone of tps repo failed"
 		exit 1
 	}
-	# Exit installation directory
+	# Exiting installation directory
 	cd - > "/dev/null"
 
 	echo
@@ -135,7 +135,7 @@ setup_tps() {
 		bash "install-tps.sh"
 	fi 
 
-	# Check if installation was successful
+	# Checking if installation was successful
 	if [ $? -ne 0 ]; then
     	fmt_error "Installation failed."
 		exit 1

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -37,7 +37,7 @@ REMOTE=${REMOTE:-https://github.com/${REPO}.git}
 BRANCH=${BRANCH:-master}
 
 command_exists() {
-	command -v "$@" >/dev/null 2>&1
+	command -v "$@" &> "/dev/null"
 }
 
 fmt_error() {

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -86,8 +86,8 @@ function clone_tps {
 
 	ostype=$(uname)
 	if [ -z "${ostype%CYGWIN*}" ] && git --version | grep -q msysgit; then
-		fmt_error "Windows/MSYS Git is not supported on Cygwin"
-		fmt_error "Make sure the Cygwin git package is installed and is first on the \$PATH"
+		fmt_error "Windows/MSYS Git is not supported on Cygwin. Make sure the" \
+			"Cygwin git package is installed and is first on the \$PATH"
 		exit 1
 	fi
 
@@ -130,8 +130,7 @@ function setup_tps {
 		echo "You might need to enter your password for installation."
 		sudo -k bash "install-tps.sh" || install_exit_code=$?
 	else
-		bash "install-tps.sh"
-		install_exit_code=$? || install_exit_code=$?
+		bash "install-tps.sh" || install_exit_code=$?
 	fi 
 
 	# Checking if installation was successful

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -13,7 +13,7 @@
 #   wget https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh
 #   bash online-installer/install.sh
 
-set -uo pipefail
+set -euo pipefail
 
 # Making sure important variables exist if not already defined
 #
@@ -126,13 +126,13 @@ function setup_tps {
 	
 	cd "${TPS_LOCAL_REPO}"
 
+	install_exit_code=0
 	if user_can_sudo; then
 		echo "You might need to enter your password for installation."
-		sudo -k bash "install-tps.sh"
-		install_exit_code=$?
+		sudo -k bash "install-tps.sh" || install_exit_code=$?
 	else
 		bash "install-tps.sh"
-		install_exit_code=$?
+		install_exit_code=$? || install_exit_code=$?
 	fi 
 
 	# Checking if installation was successful

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Adopted from oh-my-zsh standalone installation script which is licensed under MIT License.
+#
+# This script should be run via curl:
+#   bash -c "$(curl -fsSL https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
+# or via wget:
+#   bash -c "$(wget -qO- https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
+# or via fetch:
+#   bash -c "$(fetch -o - https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
+#
+# As an alternative, you can first download the install script and run it afterwards:
+#   wget https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh
+#   bash online-installer/install.sh
+
+set -euo pipefail
+
+# Make sure important variables exist if not already defined
+#
+# $USER is defined by login(1) which is not always executed (e.g. containers)
+# POSIX: https://pubs.opengroup.org/onlinepubs/009695299/utilities/id.html
+USER=${USER:-$(id -u -n)}
+# $HOME is defined at the time of login, but it could be unset. If it is unset,
+# a tilde by itself (~) will not be expanded to the current user's home directory.
+# POSIX: https://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap08.html#tag_08_03
+HOME="${HOME:-$(getent passwd $USER 2>/dev/null | cut -d: -f6)}"
+# macOS does not have getent, but this works even if $HOME is unset
+HOME="${HOME:-$(eval echo ~$USER)}"
+
+# Directory of TPS code repository
+TPS="${TPS:-$HOME/.local/share/tps}"
+
+# Tps cli file path. It will be a symlink from the code repository and the directory should be added to the path.
+TPS_BIN="${TPS_BIN:-$HOME/.local/bin/tps}"
+REPO=${REPO:-ioi-2017/tps}
+REMOTE=${REMOTE:-https://github.com/${REPO}.git}
+BRANCH=${BRANCH:-master}
+
+command_exists() {
+	command -v "$@" >/dev/null 2>&1
+}
+
+fmt_error() {
+	printf "Error: %s\n" "$*" >&2
+}
+
+clone_tps() {
+	# Prevent the cloned repository from having insecure permissions. Failing to do
+	# so causes compinit() calls to fail with "command not found: compdef" errors
+	# for users with insecure umasks (e.g., "002", allowing group writability). Note
+	# that this will be ignored under Cygwin by default, as Windows ACLs take
+	# precedence over umasks except for filesystems mounted with option "noacl".
+	umask g-w,o-w
+
+	echo -n " ########################## "
+	echo -n "Cloning TPS..."
+	echo -n " ########################## "
+	echo
+
+	command_exists git || {
+		fmt_error "git is not installed"
+		exit 1
+	}
+
+	ostype=$(uname)
+	if [ -z "${ostype%CYGWIN*}" ] && git --version | grep -q msysgit; then
+		fmt_error "Windows/MSYS Git is not supported on Cygwin"
+		fmt_error "Make sure the Cygwin git package is installed and is first on the \$PATH"
+		exit 1
+	fi
+
+	# Manual clone with git config options to support git < v1.7.2
+	mkdir -p "$TPS"
+	git init --quiet "$TPS" && cd "$TPS" \
+	&& git config core.eol lf \
+	&& git config core.autocrlf false \
+	&& git config fsck.zeroPaddedFilemode ignore \
+	&& git config fetch.fsck.zeroPaddedFilemode ignore \
+	&& git config receive.fsck.zeroPaddedFilemode ignore \
+	&& git config tps.remote origin \
+	&& git config tps.branch "$BRANCH" \
+	&& git remote add origin "$REMOTE" \
+	&& git fetch --depth=1 origin \
+	&& git checkout -b "$BRANCH" "origin/$BRANCH" || {
+		[ ! -d "$TPS" ] || {
+			cd -
+			rm -rf "$TPS" 2> "/dev/null"
+		}
+		fmt_error "git clone of tps repo failed"
+		exit 1
+	}
+	# Exit installation directory
+	cd -
+
+	echo
+}
+
+setup_tps() {
+	echo -n " ########################## "
+	echo -n "Setting up TPS"
+	echo -n " ########################## "
+	echo
+
+	TPS_BIN_DIR=$(dirname "$TPS_BIN")
+	mkdir -p "$TPS_BIN_DIR"
+
+	ln -s "$TPS/tps.sh" "$TPS_BIN"
+	chmod +x "$TPS_BIN"
+
+	echo "Installed TPS at $TPS_BIN"
+
+	command_exists tps || {
+		echo "\"$TPS_BIN_DIR\" is not in \$PATH. Adding to \$PATH for bash and zsh." \
+			"If your shell is different, add the following to your shell config:"
+		echo "export PATH=\"\$PATH:$TPS_BIN_DIR\""
+		echo "Please restart your shell to be able to run tps"
+		echo
+
+		for CONFIG_DIR in ".profile" ".bash_profile" ".zprofile" ".zshrc" ".bashrc"; do
+			echo "export PATH=\"\$PATH:$TPS_BIN_DIR\"" >> "$HOME/$CONFIG_DIR"
+		done
+	}
+
+	for CONFIG_DIR in ".profile" ".bash_profile" ".zprofile" ".zshrc" ".bashrc"; do
+		echo "export TPS=\"$TPS\"" >> "$HOME/$CONFIG_DIR"
+	done
+
+	BC_FILE="$TPS/tps.bash_completion.sh"
+
+	echo "Adding bash completion file \"$BC_FILE\" to \"~/.bashrc\" to load on bash startup." 
+	echo ". \"$BC_FILE\"" >> "$HOME/.bashrc"
+}
+
+main() {
+	!(command_exists tps) || {
+		fmt_error "tps is installed in $(command -v tps). You need to remove it if you want to reinstall."
+		exit 1
+	}
+
+	if [ -d "$TPS" ]; then
+		echo "The \$TPS folder already exists ($TPS). You need to remove it if you want to reinstall."
+		exit 1
+	fi
+
+	clone_tps
+	setup_tps
+
+	echo "TPS installed successfully. Run \"tps\" to try it out. You might need to reload your shell to get everything working."
+}
+
+main "$@"

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -43,27 +43,27 @@ function fmt_error {
 }
 
 function user_can_sudo {
-  # Checking if sudo is installed
-  command_exists "sudo" || return 1
-  # The following command has 3 parts:
-  #
-  # 1. Runs `sudo` with `-v`. Does the following:
-  #    • with privilege: asks for a password immediately.
-  #    • without privilege: exits with error code 1 and prints the message:
-  #      Sorry, user <username> may not run sudo on <hostname>
-  #
-  # 2. Passes `-n` to `sudo` to tell it to not ask for a password. If the
-  #    password is not required, the command will finish with exit code 0.
-  #    If one is required, sudo will exit with error code 1 and print the
-  #    message:
-  #    sudo: a password is required
-  #
-  # 3. Checks for the words "may not run sudo" in the output to really tell
-  #    whether the user has privileges or not. For that we have to make sure
-  #    to run `sudo` in the default locale (with `LANG=`) so that the message
-  #    stays consistent regardless of the user's locale.
-  #
-  ! LANG= sudo -n -v 2>&1 | grep -q "may not run sudo"
+	# Checking if sudo is installed
+	command_exists "sudo" || return 1
+	# The following command has 3 parts:
+	#
+	# 1. Runs `sudo` with `-v`. Does the following:
+	#    • with privilege: asks for a password immediately.
+	#    • without privilege: exits with error code 1 and prints the message:
+	#      Sorry, user <username> may not run sudo on <hostname>
+	#
+	# 2. Passes `-n` to `sudo` to tell it to not ask for a password. If the
+	#    password is not required, the command will finish with exit code 0.
+	#    If one is required, sudo will exit with error code 1 and print the
+	#    message:
+	#    sudo: a password is required
+	#
+	# 3. Checks for the words "may not run sudo" in the output to really tell
+	#    whether the user has privileges or not. For that we have to make sure
+	#    to run `sudo` in the default locale (with `LANG=`) so that the message
+	#    stays consistent regardless of the user's locale.
+	#
+	! LANG= sudo -n -v 2>&1 | grep -q "may not run sudo"
 }
 
 
@@ -137,7 +137,7 @@ function setup_tps {
 
 	# Checking if installation was successful
 	if [ "${install_exit_code}" -ne "0" ]; then
-    	fmt_error "Installation failed."
+		fmt_error "Installation failed."
 		exit 1
 	fi
 

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -13,7 +13,7 @@
 #   wget https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh
 #   bash online-installer/install.sh
 
-set -euo pipefail
+set -uo pipefail
 
 # Making sure important variables exist if not already defined
 #

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 #
 # $USER is defined by login(1) which is not always executed (e.g. containers)
 # POSIX: https://pubs.opengroup.org/onlinepubs/009695299/utilities/id.html
-USER=${USER:-$(id -u -n)}
+USER="${USER:-$(id -u -n)}"
 # $HOME is defined at the time of login, but it could be unset. If it is unset,
 # a tilde by itself (~) will not be expanded to the current user's home directory.
 # POSIX: https://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap08.html#tag_08_03
@@ -30,21 +30,19 @@ HOME="${HOME:-$(eval echo ~$USER)}"
 # Directory to store TPS code repository in
 TPS_LOCAL_REPO="${TPS_LOCAL_REPO:-$HOME/.local/share/tps}"
 
-# Tps cli file path. It will be a symlink from the code repository and the directory should be added to the path.
-TPS_BIN="${TPS_BIN:-$HOME/.local/bin/tps}"
-TPS_REMOTE_REPO=${TPS_REMOTE_REPO:-ioi-2017/tps}
-TPS_REMOTE_REPO_GIT_URL=${TPS_REMOTE_REPO_GIT_URL:-https://github.com/${TPS_REMOTE_REPO}.git}
-TPS_REMOTE_BRANCH=${TPS_REMOTE_BRANCH:-master}
+TPS_REMOTE_REPO="${TPS_REMOTE_REPO:-ioi-2017/tps}"
+TPS_REMOTE_REPO_GIT_URL="${TPS_REMOTE_REPO_GIT_URL:-https://github.com/${TPS_REMOTE_REPO}.git}"
+TPS_REMOTE_BRANCH="${TPS_REMOTE_BRANCH:-master}"
 
-command_exists() {
+function command_exists {
 	command -v "$@" &> "/dev/null"
 }
 
-fmt_error() {
+function fmt_error {
 	printf "Error: %s\n" "$*" >&2
 }
 
-user_can_sudo() {
+function user_can_sudo {
   # Checking if sudo is installed
   command_exists sudo || return 1
   # The following command has 3 parts:
@@ -69,7 +67,7 @@ user_can_sudo() {
 }
 
 
-clone_tps() {
+function clone_tps {
 	# Preventing the cloned repository from having insecure permissions. Failing to do
 	# so causes compinit() calls to fail with "command not found: compdef" errors
 	# for users with insecure umasks (e.g., "002", allowing group writability). Note
@@ -95,21 +93,21 @@ clone_tps() {
 	fi
 
 	# Manual cloning with git config options to support git < v1.7.2
-	mkdir -p "$TPS_LOCAL_REPO"
-	git init --quiet "$TPS_LOCAL_REPO" && cd "$TPS_LOCAL_REPO" \
+	mkdir -p "${TPS_LOCAL_REPO}"
+	git init --quiet "${TPS_LOCAL_REPO}" && cd "${TPS_LOCAL_REPO}" \
 	&& git config core.eol lf \
 	&& git config core.autocrlf false \
 	&& git config fsck.zeroPaddedFilemode ignore \
 	&& git config fetch.fsck.zeroPaddedFilemode ignore \
 	&& git config receive.fsck.zeroPaddedFilemode ignore \
 	&& git config tps.remote origin \
-	&& git config tps.branch "$TPS_REMOTE_BRANCH" \
-	&& git remote add origin "$TPS_REMOTE_REPO_GIT_URL" \
+	&& git config tps.branch "${TPS_REMOTE_BRANCH}" \
+	&& git remote add origin "${TPS_REMOTE_REPO_GIT_URL}" \
 	&& git fetch --depth=1 origin \
-	&& git checkout -b "$TPS_REMOTE_BRANCH" "origin/$TPS_REMOTE_BRANCH" || {
-		[ ! -d "$TPS_LOCAL_REPO" ] || {
+	&& git checkout -b "${TPS_REMOTE_BRANCH}" "origin/${TPS_REMOTE_BRANCH}" || {
+		[ ! -d "${TPS_LOCAL_REPO}" ] || {
 			cd -
-			rm -rf "$TPS_LOCAL_REPO" 2> "/dev/null"
+			rm -rf "${TPS_LOCAL_REPO}" 2> "/dev/null"
 		}
 		fmt_error "git clone of tps repo failed"
 		exit 1
@@ -120,13 +118,13 @@ clone_tps() {
 	echo
 }
 
-setup_tps() {
+function setup_tps {
 	echo -n " ########################## "
 	echo -n "Installing TPS system-wide"
 	echo -n " ########################## "
 	echo
 	
-	cd ${TPS_LOCAL_REPO}
+	cd "${TPS_LOCAL_REPO}"
 
 	if user_can_sudo; then
 		echo "You might need to enter your password for installation."
@@ -144,9 +142,9 @@ setup_tps() {
 	cd - > "/dev/null"
 }
 
-main() {
-	if [ -d "$TPS_LOCAL_REPO" ]; then
-		echo "The \$TPS_LOCAL_REPO folder already exists ($TPS_LOCAL_REPO). You need to remove it if you want to reinstall."
+function main {
+	if [ -d "${TPS_LOCAL_REPO}" ]; then
+		echo "The \$TPS_LOCAL_REPO folder already exists (${TPS_LOCAL_REPO}). You need to remove it if you want to reinstall."
 		exit 1
 	fi
 

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -23,7 +23,7 @@ USER=${USER:-$(id -u -n)}
 # $HOME is defined at the time of login, but it could be unset. If it is unset,
 # a tilde by itself (~) will not be expanded to the current user's home directory.
 # POSIX: https://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap08.html#tag_08_03
-HOME="${HOME:-$(getent passwd $USER 2>/dev/null | cut -d: -f6)}"
+HOME="${HOME:-$(getent passwd $USER 2> "/dev/null" | cut -d: -f6)}"
 # macOS does not have getent, but this works even if $HOME is unset
 HOME="${HOME:-$(eval echo ~$USER)}"
 

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -129,12 +129,14 @@ function setup_tps {
 	if user_can_sudo; then
 		echo "You might need to enter your password for installation."
 		sudo -k bash "install-tps.sh"
+		install_exit_code=$?
 	else
 		bash "install-tps.sh"
+		install_exit_code=$?
 	fi 
 
 	# Checking if installation was successful
-	if [ $? -ne 0 ]; then
+	if [ "${install_exit_code}" -ne "0" ]; then
     	fmt_error "Installation failed."
 		exit 1
 	fi

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -44,7 +44,7 @@ function fmt_error {
 
 function user_can_sudo {
   # Checking if sudo is installed
-  command_exists sudo || return 1
+  command_exists "sudo" || return 1
   # The following command has 3 parts:
   #
   # 1. Runs `sudo` with `-v`. Does the following:
@@ -80,7 +80,7 @@ function clone_tps {
 	echo -n " ########################## "
 	echo
 
-	command_exists git || {
+	command_exists "git" || {
 		fmt_error "git is not installed"
 		exit 1
 	}

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -28,13 +28,13 @@ HOME="${HOME:-$(getent passwd $USER 2>/dev/null | cut -d: -f6)}"
 HOME="${HOME:-$(eval echo ~$USER)}"
 
 # Directory of TPS code repository
-TPS="${TPS:-$HOME/.local/share/tps}"
+TPS_LOCAL_REPO="${TPS_LOCAL_REPO:-$HOME/.local/share/tps}"
 
 # Tps cli file path. It will be a symlink from the code repository and the directory should be added to the path.
 TPS_BIN="${TPS_BIN:-$HOME/.local/bin/tps}"
-REPO=${REPO:-ioi-2017/tps}
-REMOTE=${REMOTE:-https://github.com/${REPO}.git}
-BRANCH=${BRANCH:-master}
+TPS_REMOTE_REPO=${TPS_REMOTE_REPO:-ioi-2017/tps}
+TPS_REMOTE_REPO_GIT_URL=${TPS_REMOTE_REPO_GIT_URL:-https://github.com/${TPS_REMOTE_REPO}.git}
+TPS_REMOTE_BRANCH=${TPS_REMOTE_BRANCH:-master}
 
 command_exists() {
 	command -v "$@" >/dev/null 2>&1
@@ -53,7 +53,7 @@ clone_tps() {
 	umask g-w,o-w
 
 	echo -n " ########################## "
-	echo -n "Cloning TPS..."
+	echo -n "Cloning TPS Repo..."
 	echo -n " ########################## "
 	echo
 
@@ -70,21 +70,21 @@ clone_tps() {
 	fi
 
 	# Manual clone with git config options to support git < v1.7.2
-	mkdir -p "$TPS"
-	git init --quiet "$TPS" && cd "$TPS" \
+	mkdir -p "$TPS_LOCAL_REPO"
+	git init --quiet "$TPS_LOCAL_REPO" && cd "$TPS_LOCAL_REPO" \
 	&& git config core.eol lf \
 	&& git config core.autocrlf false \
 	&& git config fsck.zeroPaddedFilemode ignore \
 	&& git config fetch.fsck.zeroPaddedFilemode ignore \
 	&& git config receive.fsck.zeroPaddedFilemode ignore \
 	&& git config tps.remote origin \
-	&& git config tps.branch "$BRANCH" \
-	&& git remote add origin "$REMOTE" \
+	&& git config tps.branch "$TPS_REMOTE_BRANCH" \
+	&& git remote add origin "$TPS_REMOTE_REPO_GIT_URL" \
 	&& git fetch --depth=1 origin \
-	&& git checkout -b "$BRANCH" "origin/$BRANCH" || {
-		[ ! -d "$TPS" ] || {
+	&& git checkout -b "$TPS_REMOTE_BRANCH" "origin/$TPS_REMOTE_BRANCH" || {
+		[ ! -d "$TPS_LOCAL_REPO" ] || {
 			cd -
-			rm -rf "$TPS" 2> "/dev/null"
+			rm -rf "$TPS_LOCAL_REPO" 2> "/dev/null"
 		}
 		fmt_error "git clone of tps repo failed"
 		exit 1
@@ -104,7 +104,7 @@ setup_tps() {
 	TPS_BIN_DIR=$(dirname "$TPS_BIN")
 	mkdir -p "$TPS_BIN_DIR"
 
-	ln -s "$TPS/tps.sh" "$TPS_BIN"
+	ln -s "$TPS_LOCAL_REPO/tps.sh" "$TPS_BIN"
 	chmod +x "$TPS_BIN"
 
 	echo "Installed TPS at $TPS_BIN"
@@ -122,10 +122,10 @@ setup_tps() {
 	}
 
 	for CONFIG_DIR in ".profile" ".bash_profile" ".zprofile" ".zshrc" ".bashrc"; do
-		echo "export TPS=\"$TPS\"" >> "$HOME/$CONFIG_DIR"
+		echo "export TPS_LOCAL_REPO=\"$TPS_LOCAL_REPO\"" >> "$HOME/$CONFIG_DIR"
 	done
 
-	BC_FILE="$TPS/tps.bash_completion.sh"
+	BC_FILE="$TPS_LOCAL_REPO/tps.bash_completion.sh"
 
 	echo "Adding bash completion file \"$BC_FILE\" to \"~/.bashrc\" to load on bash startup." 
 	echo ". \"$BC_FILE\"" >> "$HOME/.bashrc"
@@ -137,8 +137,8 @@ main() {
 		exit 1
 	}
 
-	if [ -d "$TPS" ]; then
-		echo "The \$TPS folder already exists ($TPS). You need to remove it if you want to reinstall."
+	if [ -d "$TPS_LOCAL_REPO" ]; then
+		echo "The \$TPS_LOCAL_REPO folder already exists ($TPS_LOCAL_REPO). You need to remove it if you want to reinstall."
 		exit 1
 	fi
 

--- a/online-installer/install.sh
+++ b/online-installer/install.sh
@@ -30,8 +30,7 @@ HOME="${HOME:-$(eval echo ~$USER)}"
 # Directory to store TPS code repository in
 TPS_LOCAL_REPO="${TPS_LOCAL_REPO:-$HOME/.local/share/tps}"
 
-TPS_REMOTE_REPO="${TPS_REMOTE_REPO:-ioi-2017/tps}"
-TPS_REMOTE_REPO_GIT_URL="${TPS_REMOTE_REPO_GIT_URL:-https://github.com/${TPS_REMOTE_REPO}.git}"
+TPS_REMOTE_REPO_GIT_URL="${TPS_REMOTE_REPO_GIT_URL:-https://github.com/ioi-2017/tps.git}"
 TPS_REMOTE_BRANCH="${TPS_REMOTE_BRANCH:-master}"
 
 function command_exists {


### PR DESCRIPTION
This PR adds an online installer scripts which will enable one line installation of tps using:

```
bash -c "$(curl -fsSL https://raw.githubusercontent.com/ioi-2017/tps/master/online-installer/install.sh)"
```

It will also clone the tps repo to `~/.local/share/tps` (or configured `$TPS_LOCAL_REPO`) to be able to use its data (such as `scripts`) in the future.
 
I tested this script in Mac and Linux (via docker) in both bash and zsh.
